### PR TITLE
Rename iter_chain to chain, and remove iter_sources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "error-iter"
-description = "Error::iter_chain and Error::iter_sources on stable Rust"
+description = "Error::chain on stable Rust"
 repository = "https://github.com/parasyte/error-iter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # `error-iter`
 
+[![Documentation](https://docs.rs/error-iter/badge.svg)](https://docs.rs/error-iter)
 [![Build Status](https://travis-ci.org/parasyte/error-iter.svg?branch=master)](https://travis-ci.org/parasyte/error-iter)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
-Use [`Error::iter_chain`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.iter_chain) and [`Error::iter_sources`](https://doc.rust-lang.org/stable/std/error/trait.Error.html#method.iter_sources) on stable Rust.
+Use [`Error::chain`](https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.chain) on stable Rust.
 
 ## MSRV
 
@@ -13,7 +14,7 @@ Compiles on Rust 1.31.0, but does not return the tail source. (Tests fail on any
 
 ## What is this?
 
-`iter_chain` and `iter_sources` are incredibly useful for providing error context in Rust applications. For motivation, see [RFC 2504](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md). These iterators are available in nightly compilers with [#58520](https://github.com/rust-lang/rust/issues/58520) tracking stabilization.
+`Error::chain` is incredibly useful for providing error context in Rust applications. For motivation, see [RFC 2504](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md). This iterator is available in nightly compilers with [#58520](https://github.com/rust-lang/rust/issues/58520) tracking stabilization.
 
 This crate does not attempt to be 100% compatible with the stabilization effort, but does want to provide very similar functionality to stable Rust.
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,7 +17,7 @@ fn main() {
     let error = Error::from(IoError::new(ErrorKind::Other, "oh no!"));
 
     eprintln!("Error: {}", error);
-    for source in error.iter_sources() {
+    for source in error.chain().skip(1) {
         eprintln!("  Caused by: {}", source);
     }
 }


### PR DESCRIPTION
Update to the latest unstable API.