### PR TITLE
Update to latest unstable API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "error-iter"
-description = "Error::chain on stable Rust"
+description = "Error::sources on stable Rust"
 repository = "https://github.com/parasyte/error-iter"
 version = "0.2.0"
 authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 readme = "README.md"
-keywords = ["chain", "error", "iter", "iterator", "sources"]
+keywords = ["error", "iter", "iterator", "recursive", "sources"]
 categories = ["rust-patterns"]
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/parasyte)](https://github.com/sponsors/parasyte "Sponsors")
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
-Use [`Error::chain`](https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.chain) on stable Rust.
+Use [`Error::sources`](https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.sources) on stable Rust.
 
 ## MSRV
 
@@ -17,7 +17,7 @@ Compiles on Rust 1.31.0, but does not return the tail source. (Tests fail on any
 
 ## What is this?
 
-`Error::chain` is incredibly useful for providing error context in Rust applications. For motivation, see [RFC 2504](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md). This iterator is available in nightly compilers with [#58520](https://github.com/rust-lang/rust/issues/58520) tracking stabilization.
+`Error::sources` is incredibly useful for providing error context in Rust applications. For motivation, see [RFC 2504](https://github.com/rust-lang/rfcs/blob/master/text/2504-fix-error.md). This iterator is available in nightly compilers with [#58520](https://github.com/rust-lang/rust/issues/58520) tracking stabilization.
 
 This crate does not attempt to be 100% compatible with the stabilization effort, but does want to provide very similar functionality to stable Rust.
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,7 +17,7 @@ fn main() {
     let error = Error::from(IoError::new(ErrorKind::Other, "oh no!"));
 
     eprintln!("Error: {}", error);
-    for source in error.chain().skip(1) {
+    for source in error.sources().skip(1) {
         eprintln!("  Caused by: {}", source);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!     let error = Error::from(IoError::new(ErrorKind::Other, "oh no!"));
 //!
 //!     eprintln!("Error: {}", error);
-//!     for source in error.chain().skip(1) {
+//!     for source in error.sources().skip(1) {
 //!         eprintln!("  Caused by: {}", source);
 //!     }
 //! }
@@ -51,7 +51,7 @@ impl<'a> Iterator for ErrorIterator<'a> {
 ///
 /// The default implementation provides iterators for any type that implements `std::error::Error`.
 pub trait ErrorIter: std::error::Error + Sized + 'static {
-    /// Create an iterator over the error and its chained sources.
+    /// Create an iterator over the error and its recursive sources.
     ///
     /// ```
     /// use error_iter::ErrorIter;
@@ -70,14 +70,14 @@ pub trait ErrorIter: std::error::Error + Sized + 'static {
     ///
     /// let error = Error::Nested(Box::new(Error::Leaf));
     ///
-    /// let mut iter = error.chain();
+    /// let mut iter = error.sources();
     ///
     /// assert_eq!("Nested error: Leaf error".to_string(), iter.next().unwrap().to_string());
     /// assert_eq!("Leaf error".to_string(), iter.next().unwrap().to_string());
     /// assert!(iter.next().is_none());
     /// assert!(iter.next().is_none());
     /// ```
-    fn chain(&self) -> ErrorIterator {
+    fn sources(&self) -> ErrorIterator {
         ErrorIterator { inner: Some(self) }
     }
 }
@@ -99,10 +99,10 @@ mod tests {
     impl ErrorIter for Error {}
 
     #[test]
-    fn iter_chain_ok() {
+    fn iter_sources_ok() {
         let error = Error::Nested(Box::new(Error::Nested(Box::new(Error::Leaf))));
 
-        let mut iter = error.chain();
+        let mut iter = error.sources();
 
         assert_eq!(
             "Nested error: Nested error: Leaf error".to_string(),


### PR DESCRIPTION
- Renames `chain` to `sources` following https://github.com/rust-lang/rust/pull/100955