### PR TITLE
Prepare 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,25 +4,25 @@ version = 3
 
 [[package]]
 name = "error-iter"
-version = "0.4.1"
+version = "1.0.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -60,6 +60,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "error-iter"
 description = "Error::sources on stable Rust"
 repository = "https://github.com/parasyte/error-iter"
-version = "0.4.1"
+version = "1.0.0"
 authors = ["Jay Oster <jay@kodewerx.org>"]
 edition = "2018"
 readme = "README.md"
@@ -14,7 +14,7 @@ license = "MIT"
 rust-version = "1.37"
 
 [badges]
-maintenance = { status = "experimental" }
+maintenance = { status = "passively-maintained" }
 
 [dev-dependencies]
 thiserror = "=1.0.39"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,18 +1,19 @@
-use error_iter::ErrorIter as _;
-use std::io::{Error as IoError, ErrorKind};
+use error_iter::ErrorExt as _;
+use std::io;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 enum Error {
     #[error("I/O Error")]
-    Io(#[from] IoError),
+    Io(#[from] io::Error),
 
     #[error("Unknown error")]
     _Unknown,
 }
 
 fn main() {
-    let error = Error::from(IoError::new(ErrorKind::Other, "oh no!"));
+    let inner = io::Error::new(io::ErrorKind::Other, "oh no!");
+    let error = Error::from(inner);
 
     eprintln!("Error: {}", error);
     for source in error.sources().skip(1) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,22 @@
 //! Iterators over `std::error::Error` sources on stable Rust.
 //!
 //! ```
-//! use error_iter::ErrorIter as _;
-//! use std::io::{Error as IoError, ErrorKind};
+//! use error_iter::ErrorExt as _;
+//! use std::io;
 //! use thiserror::Error;
 //!
 //! #[derive(Debug, Error)]
 //! enum Error {
 //!     #[error("I/O Error")]
-//!     Io(#[from] IoError),
+//!     Io(#[from] io::Error),
 //!
 //!     #[error("Unknown error")]
 //!     Unknown,
 //! }
 //!
 //! fn do_something() {
-//!     let error = Error::from(IoError::new(ErrorKind::Other, "oh no!"));
+//!     let inner = io::Error::new(io::ErrorKind::Other, "oh no!");
+//!     let error = Error::from(inner);
 //!
 //!     eprintln!("Error: {}", error);
 //!     for source in error.sources().skip(1) {
@@ -48,11 +49,11 @@ impl<'a> Iterator for ErrorIterator<'a> {
 /// Implement this trait on your error types for free iterators over their sources!
 ///
 /// The default implementation provides iterators for any type that implements `std::error::Error`.
-pub trait ErrorIter: std::error::Error + Sized + 'static {
+pub trait ErrorExt: std::error::Error + Sized + 'static {
     /// Create an iterator over the error and its recursive sources.
     ///
     /// ```
-    /// use error_iter::ErrorIter as _;
+    /// use error_iter::ErrorExt as _;
     /// use thiserror::Error;
     ///
     /// #[derive(Debug, Error)]
@@ -78,7 +79,7 @@ pub trait ErrorIter: std::error::Error + Sized + 'static {
     }
 }
 
-impl<T> ErrorIter for T where T: std::error::Error + Sized + 'static {}
+impl<T> ErrorExt for T where T: std::error::Error + Sized + 'static {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Breaking change: `ErrorIter` trait is now named `ErrorExt`.