### PR TITLE
Allow `.sources()` to be accessed on `&(dyn std::error::Error + 'static)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: cargo test --workspace
 
   checks_old:
-    name: Check 1.56.0
+    name: Check 1.81.0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -81,7 +81,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.56.0
+          toolchain: 1.81.0
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         run: cargo check --all
 
   tests_old:
-    name: Test 1.56.0
+    name: Test 1.81.0
     runs-on: ubuntu-latest
     needs: [checks, lints]
     steps:
@@ -101,7 +101,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.56.0
+          toolchain: 1.81.0
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/examples/dyn_error.rs
+++ b/examples/dyn_error.rs
@@ -1,0 +1,30 @@
+use error_iter::ErrorExt as _;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("Failure")]
+    Std(#[from] Box<dyn std::error::Error + 'static>),
+
+    #[error("Unknown error")]
+    _Unknown,
+}
+
+fn main() {
+    let error = Box::<dyn std::error::Error + 'static>::from("oh no!");
+
+    let errors = error_strings(&*error);
+    assert_eq!(vec!["oh no!"], errors);
+    eprintln!("Errors: {errors:#?}");
+
+    let error = Error::from(error);
+
+    let errors = error_strings(&error);
+    assert_eq!(vec!["Failure", "oh no!"], errors);
+    eprintln!("Errors: {errors:#?}");
+}
+
+fn error_strings(err: &(dyn std::error::Error + 'static)) -> Vec<String> {
+    #[expect(unstable_name_collisions)]
+    err.sources().map(|err| err.to_string()).collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl std::iter::FusedIterator for ErrorIterator<'_> {}
 /// Implement this trait on your error types for free iterators over their sources!
 ///
 /// The default implementation provides iterators for any type that implements `std::error::Error`.
-pub trait ErrorExt: std::error::Error + Sized + 'static {
+pub trait ErrorExt: std::error::Error + 'static {
     /// Create an iterator over the error and its recursive sources.
     ///
     /// ```
@@ -84,12 +84,23 @@ pub trait ErrorExt: std::error::Error + Sized + 'static {
     /// assert!(iter.next().is_none());
     /// assert!(iter.next().is_none());
     /// ```
+    fn sources(&self) -> ErrorIterator<'_>;
+}
+
+impl<T> ErrorExt for T
+where
+    T: std::error::Error + 'static,
+{
     fn sources(&self) -> ErrorIterator<'_> {
         ErrorIterator { inner: Some(self) }
     }
 }
 
-impl<T> ErrorExt for T where T: std::error::Error + Sized + 'static {}
+impl ErrorExt for dyn std::error::Error + 'static {
+    fn sources(&self) -> ErrorIterator<'_> {
+        ErrorIterator { inner: Some(self) }
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
* Adjusted supertraits and implementations of `ErrorExt` for more flexibility.
* Fixes #17